### PR TITLE
Add information display unit function

### DIFF
--- a/src/builder/include/open_converter.h
+++ b/src/builder/include/open_converter.h
@@ -77,7 +77,6 @@ class OpenConverter : public QMainWindow {
     // nuit formatting functions
     QString formatBitrate(int64_t bitsPerSec);
     QString formatFrequency(int64_t hertz);
-    QString formatChannels(int channels);
 
     // loads a language by the given language shortcur (e.g. de, en)
     void loadLanguage(const QString &rLanguage);

--- a/src/builder/include/open_converter.h
+++ b/src/builder/include/open_converter.h
@@ -74,8 +74,10 @@ class OpenConverter : public QMainWindow {
     ~OpenConverter();
 
   private:
-    // nuit formatting functions
+    // intelligent conversion of bit rate units
     QString formatBitrate(int64_t bitsPerSec);
+
+    // intelligent conversion of frequency units
     QString formatFrequency(int64_t hertz);
 
     // loads a language by the given language shortcur (e.g. de, en)

--- a/src/builder/include/open_converter.h
+++ b/src/builder/include/open_converter.h
@@ -74,6 +74,11 @@ class OpenConverter : public QMainWindow {
     ~OpenConverter();
 
   private:
+    // nuit formatting functions
+    QString formatBitrate(int64_t bitsPerSec);
+    QString formatFrequency(int64_t hertz);
+    QString formatChannels(int channels);
+
     // loads a language by the given language shortcur (e.g. de, en)
     void loadLanguage(const QString &rLanguage);
 

--- a/src/builder/src/open_converter.cpp
+++ b/src/builder/src/open_converter.cpp
@@ -247,31 +247,61 @@ void OpenConverter::convert_Pushed() {
                                  ui->lineEdit_outputFile->text());
 }
 
+    // automatically select kbps/Mbps
+QString OpenConverter::formatBitrate(int64_t bitsPerSec) {
+    const double kbps = bitsPerSec / 1000.0;
+    if (kbps >= 1000.0) {
+        return QString("%1 Mbps").arg(kbps / 1000.0, 0, 'f', 1);
+    }
+    return QString("%1 kbps").arg(kbps, 0, 'f', 1);
+}
+
+    // automatically select Hz/kHz/MHz
+QString OpenConverter::formatFrequency(int64_t hertz) {
+    const double kHz = hertz / 1000.0;
+    if (kHz >= 1000.0) {
+        return QString("%1 MHz").arg(kHz / 1000.0, 0, 'f', 2);
+    } else if (kHz >= 1.0) {
+        return QString("%1 kHz").arg(kHz, 0, 'f', 1);
+    }
+    return QString("%1 Hz").arg(hertz);
+}
+
+    // number of channels in singular or plural form
+QString OpenConverter::formatChannels(int channels) {
+    return QString("%1 %2").arg(channels).arg(
+        (channels == 1) ? tr("channel") : tr("channels"));
+}
+
 void OpenConverter::info_Display(QuickInfo *quickInfo) {
     // video
     ui->label_videoStreamResult->setText(
         QString("%1").arg(quickInfo->videoIdx));
-    ui->label_widthResult->setText(QString("%1").arg(quickInfo->width));
-    ui->label_heightResult->setText(QString("%1").arg(quickInfo->height));
+    ui->label_widthResult->setText(
+        QString("%1 px").arg(quickInfo->width));
+    ui->label_heightResult->setText(
+        QString("%1 px").arg(quickInfo->height));
     ui->label_colorSpaceResult->setText(
         QString("%1").arg(QString::fromStdString(quickInfo->colorSpace)));
     ui->label_videoCodecResult->setText(
         QString("%1").arg(QString::fromStdString(quickInfo->videoCodec)));
     ui->label_videoBitRateResult->setText(
-        QString("%1").arg(quickInfo->videoBitRate));
-    ui->label_frameRateResult->setText(QString("%1").arg(quickInfo->frameRate));
+        formatBitrate(quickInfo->videoBitRate));
+    ui->label_frameRateResult->setText(
+        QString("%1 fps").arg(quickInfo->frameRate,0,'f',2));
     // audio
     ui->label_audioStreamResult->setText(
         QString("%1").arg(quickInfo->audioIdx));
     ui->label_audioCodecResult->setText(
         QString("%1").arg(QString::fromStdString(quickInfo->audioCodec)));
     ui->label_audioBitRateResult->setText(
-        QString("%1").arg(quickInfo->audioBitRate));
-    ui->label_channelsResult->setText(QString("%1").arg(quickInfo->channels));
+        formatBitrate(quickInfo->audioBitRate));
+    ui->label_channelsResult->setText(
+        formatChannels(quickInfo->channels));
     ui->label_sampleFmtResult->setText(
         QString("%1").arg(QString::fromStdString(quickInfo->sampleFmt)));
     ui->label_sampleRateResult->setText(
-        QString("%1").arg(quickInfo->sampleRate));
+        formatFrequency(quickInfo->sampleRate));
 }
 
 OpenConverter::~OpenConverter() {

--- a/src/builder/src/open_converter.cpp
+++ b/src/builder/src/open_converter.cpp
@@ -267,12 +267,6 @@ QString OpenConverter::formatFrequency(int64_t hertz) {
     return QString("%1 Hz").arg(hertz);
 }
 
-    // number of channels in singular or plural form
-QString OpenConverter::formatChannels(int channels) {
-    return QString("%1 %2").arg(channels).arg(
-        (channels == 1) ? tr("channel") : tr("channels"));
-}
-
 void OpenConverter::info_Display(QuickInfo *quickInfo) {
     // video
     ui->label_videoStreamResult->setText(
@@ -297,7 +291,7 @@ void OpenConverter::info_Display(QuickInfo *quickInfo) {
     ui->label_audioBitRateResult->setText(
         formatBitrate(quickInfo->audioBitRate));
     ui->label_channelsResult->setText(
-        formatChannels(quickInfo->channels));
+        QString("%1").arg(quickInfo->channels));
     ui->label_sampleFmtResult->setText(
         QString("%1").arg(QString::fromStdString(quickInfo->sampleFmt)));
     ui->label_sampleRateResult->setText(

--- a/src/builder/src/open_converter.cpp
+++ b/src/builder/src/open_converter.cpp
@@ -247,7 +247,7 @@ void OpenConverter::convert_Pushed() {
                                  ui->lineEdit_outputFile->text());
 }
 
-    // automatically select kbps/Mbps
+// automatically select kbps/Mbps
 QString OpenConverter::formatBitrate(int64_t bitsPerSec) {
     const double kbps = bitsPerSec / 1000.0;
     if (kbps >= 1000.0) {
@@ -256,7 +256,7 @@ QString OpenConverter::formatBitrate(int64_t bitsPerSec) {
     return QString("%1 kbps").arg(kbps, 0, 'f', 1);
 }
 
-    // automatically select Hz/kHz/MHz
+// automatically select Hz/kHz/MHz
 QString OpenConverter::formatFrequency(int64_t hertz) {
     const double kHz = hertz / 1000.0;
     if (kHz >= 1000.0) {


### PR DESCRIPTION
- Add the function of automatic bitrate unit conversion, converting between kbps and Mbps.

- Add the function of hierarchical display for frequency units, including Hz, kHz, and MHz.

- Enable the processing of both singular and plural forms of channel numbers