### PR TITLE
add audio and video extraction function

### DIFF
--- a/src/transcoder/src/transcoder_ffmpeg.cpp
+++ b/src/transcoder/src/transcoder_ffmpeg.cpp
@@ -33,7 +33,10 @@ bool TranscoderFFmpeg::transcode(std::string input_path,
         copyAudio = false;
     }
 
-    open_Media(decoder, encoder);
+    if(!open_Media(decoder, encoder)){
+        flag = false;
+        goto end;
+    }
 
     if (!prepare_Decoder(decoder)) {
         flag = false;
@@ -43,6 +46,10 @@ bool TranscoderFFmpeg::transcode(std::string input_path,
     for (int i = 0; i < decoder->fmtCtx->nb_streams; i++) {
         if (decoder->fmtCtx->streams[i]->codecpar->codec_type ==
             AVMEDIA_TYPE_VIDEO) {
+            // skip video streams
+            if (encoder->fmtCtx->oformat->video_codec == AV_CODEC_ID_NONE) {
+                continue;
+            }
             if (!copyVideo) {
                 ret = prepare_Encoder_Video(decoder, encoder);
                 if (ret < 0) {
@@ -54,6 +61,10 @@ bool TranscoderFFmpeg::transcode(std::string input_path,
             }
         } else if (decoder->fmtCtx->streams[i]->codecpar->codec_type ==
                    AVMEDIA_TYPE_AUDIO) {
+            // skip audio streams
+            if (encoder->fmtCtx->oformat->audio_codec == AV_CODEC_ID_NONE) {
+                continue;
+            }
             if (!copyAudio) {
                 ret = prepare_Encoder_Audio(decoder, encoder);
                 if (ret < 0) {
@@ -86,6 +97,9 @@ bool TranscoderFFmpeg::transcode(std::string input_path,
     // read video data from multimedia files to write into destination file
     while (av_read_frame(decoder->fmtCtx, decoder->pkt) >= 0) {
         if (decoder->pkt->stream_index == decoder->videoIdx) {
+            if(encoder->fmtCtx->oformat->video_codec == AV_CODEC_ID_NONE) {
+                continue;
+            }
             if (!copyVideo) {
                 transcode_Video(decoder, encoder);
             } else {
@@ -96,6 +110,9 @@ bool TranscoderFFmpeg::transcode(std::string input_path,
             // encode(oFmtCtx, outCodecCtx, outFrame, outPkt, inStream,
             // outStream);
         } else if (decoder->pkt->stream_index == decoder->audioIdx) {
+            if(encoder->fmtCtx->oformat->audio_codec == AV_CODEC_ID_NONE) {
+                continue;
+            }
             if (!copyAudio) {
                 transcode_Audio(decoder, encoder);
             } else {
@@ -327,6 +344,14 @@ bool TranscoderFFmpeg::transcode_Audio(StreamContext *decoder,
 
 bool TranscoderFFmpeg::prepare_Decoder(StreamContext *decoder) {
     int ret = -1;
+    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
+
+    ret = avformat_find_stream_info(decoder->fmtCtx, NULL);
+    if (ret < 0) {
+        av_strerror(ret, errbuf, sizeof(errbuf));
+        av_log(NULL, AV_LOG_ERROR, "avformat_find_info failed: %s\n", errbuf);
+        return false;
+    }
 
     for (int i = 0; i < decoder->fmtCtx->nb_streams; i++) {
         if (decoder->fmtCtx->streams[i]->codecpar->codec_type ==
@@ -580,6 +605,8 @@ bool TranscoderFFmpeg::prepare_Copy(AVFormatContext *avCtx, AVStream **stream,
 
 bool TranscoderFFmpeg::remux(AVPacket *pkt, AVFormatContext *avCtx,
                              AVStream *inStream, AVStream *outStream) {
+    // associate the avpacket with the target output avstream
+    pkt->stream_index = outStream->index;
     av_packet_rescale_ts(pkt, inStream->time_base, outStream->time_base);
     if (av_interleaved_write_frame(avCtx, pkt) < 0) {
         av_log(NULL, AV_LOG_ERROR, "write frame error!\n");

--- a/src/transcoder/src/transcoder_ffmpeg.cpp
+++ b/src/transcoder/src/transcoder_ffmpeg.cpp
@@ -344,14 +344,6 @@ bool TranscoderFFmpeg::transcode_Audio(StreamContext *decoder,
 
 bool TranscoderFFmpeg::prepare_Decoder(StreamContext *decoder) {
     int ret = -1;
-    char errbuf[AV_ERROR_MAX_STRING_SIZE] = {0};
-
-    ret = avformat_find_stream_info(decoder->fmtCtx, NULL);
-    if (ret < 0) {
-        av_strerror(ret, errbuf, sizeof(errbuf));
-        av_log(NULL, AV_LOG_ERROR, "avformat_find_info failed: %s\n", errbuf);
-        return false;
-    }
 
     for (int i = 0; i < decoder->fmtCtx->nb_streams; i++) {
         if (decoder->fmtCtx->streams[i]->codecpar->codec_type ==


### PR DESCRIPTION
Taking the extraction of an AAC audio stream as an example, the original code fails to achieve this primarily because the AAC frames obtained through demultiplexing lack ADTS headers, which the ADTS muxer cannot recognize, causing errors. 

My solution is to have the code directly copy the stream without handling ADTS headers. 

The detailed implementation method is: check whether the encoder name specified by the user matches the encoder name of the input stream; if they match, directly copy the stream, and eliminate interference from video streams.