### PR TITLE
transcoder_ffmpeg: fix memleak of encoder fmtCtx and filter_graph

### DIFF
--- a/src/transcoder/src/transcoder_ffmpeg.cpp
+++ b/src/transcoder/src/transcoder_ffmpeg.cpp
@@ -195,7 +195,8 @@ int TranscoderFFmpeg::init_filter(AVCodecContext *dec_ctx, FilteringContext *fil
 end:
     avfilter_inout_free(&inputs);
     avfilter_inout_free(&outputs);
-
+    if (ret < 0)
+        avfilter_graph_free(&filter_graph);
     return ret;
 }
 
@@ -541,8 +542,11 @@ end:
         decoder = nullptr;
     }
 
-    if (encoder && encoder->fmtCtx && !(encoder->fmtCtx->oformat->flags & AVFMT_NOFILE)) {
-        avio_closep(&encoder->fmtCtx->pb);
+    if (encoder && encoder->fmtCtx) {
+        if (!(encoder->fmtCtx->oformat->flags & AVFMT_NOFILE))
+            avio_closep(&encoder->fmtCtx->pb);
+        avformat_free_context(encoder->fmtCtx);
+        encoder->fmtCtx = NULL;
     }
     if (encoder) {
         delete encoder;


### PR DESCRIPTION
- Call avformat_free_context on encoder->fmtCtx in cleanup to free streams, codec contexts, codec parameters, and internal packets allocated by avformat_alloc_output_context2 and avformat_write_header
- Free filter_graph in init_filter when an error occurs before it is assigned to filter_ctx->filter_graph